### PR TITLE
Remove domain part, not needed.

### DIFF
--- a/resolver/files/resolv.conf
+++ b/resolver/files/resolv.conf
@@ -1,4 +1,3 @@
-domain {{ domainname }}
 search {{ searchpath }}
 {%- for nameserver in nameservers %}
 nameserver {{ nameserver }}

--- a/resolver/init.sls
+++ b/resolver/init.sls
@@ -11,6 +11,5 @@
     - source: salt://resolver/files/resolv.conf
     - template: jinja
     - defaults:
-        domainname: 'example.com'
         nameservers: ['8.8.8.8','8.8.4.4']
         searchpath: 'example.com'


### PR DESCRIPTION
As stated in resolv.conf(5) man page:
The domain and search keywords are mutually exclusive.
If more than one instance of these keywords is present,
the last instance wins.
