### PR TITLE
searchpaths should be a list

### DIFF
--- a/resolver/init.sls
+++ b/resolver/init.sls
@@ -12,5 +12,5 @@
     - template: jinja
     - defaults:
         nameservers: {{ salt['pillar.get']('resolver:nameservers', ['8.8.8.8','8.8.4.4']) }}
-        searchpaths: {{ salt['pillar.get']('resolver:searchpaths', salt['grains.get']('domain')) }}
+        searchpaths: {{ salt['pillar.get']('resolver:searchpaths', [salt['grains.get']('domain'),]) }}
         options: {{ salt['pillar.get']('resolver:options', []) }}


### PR DESCRIPTION
The template loops over searchpaths. If you don't set it in the pillar, it uses the domain from grains (which is a string).