### PR TITLE
Fix resolvconf availability on Debian family systems

### DIFF
--- a/resolver/init.sls
+++ b/resolver/init.sls
@@ -3,7 +3,7 @@
 #####################################
 
 {% if salt['pillar.get']('resolver:use_resolvconf', True) %}
-  {% set is_resolvconf_enabled = grains['os'] in ('Ubuntu', 'Debian') and salt['pkg.version']('resolvconf') %}
+  {% set is_resolvconf_enabled = grains['os_family'] in ('Debian') and salt['pkg.latest_version']('resolvconf') %}
 {% else %}
   {% set is_resolvconf_enabled = False %}
 {% endif %}


### PR DESCRIPTION
If `resolver:use_resolvconf` is set to True, there is a test to see if the OS is Ubuntu or Debian, and that there is a resolvconf version.  
The pre-pull request version used `pkg.version` which does not return any value unless there is currently a version installed.  The result is that the conditional fails, and no resolvconf is installed.

Switched the grain check to `os_family` to cover all Debian family systems, including Ubuntu, that should support the install of `resolvconf`.  Left it as an 'in' check, so that supported families could just be added in.

Switched the `pkg.version` to `pkg.latest_version` which will return with available (not just installed) version(s), satisfying the test.