### PR TITLE
Fixes for apt resolvconf package install

### DIFF
--- a/resolver/init.sls
+++ b/resolver/init.sls
@@ -3,9 +3,7 @@
 #####################################
 
 {% if salt['pillar.get']('resolver:use_resolvconf', True) %}
-  {% set is_resolvconf_enabled = grains['os_family'] in ('Debian') and 
-        (salt['pkg.latest_version']('resolvconf') or 
-         salt['pkg.version']('resolvconf')) %}
+  {% set is_resolvconf_enabled = grains['os_family'] in ('Debian') %}
 {% else %}
   {% set is_resolvconf_enabled = False %}
 {% endif %}

--- a/resolver/init.sls
+++ b/resolver/init.sls
@@ -3,7 +3,9 @@
 #####################################
 
 {% if salt['pillar.get']('resolver:use_resolvconf', True) %}
-  {% set is_resolvconf_enabled = grains['os'] in ('Ubuntu', 'Debian') and salt['pkg.version']('resolvconf') %}
+  {% set is_resolvconf_enabled = grains['os_family'] in ('Debian') and 
+        (salt['pkg.latest_version']('resolvconf') or 
+         salt['pkg.version']('resolvconf')) %}
 {% else %}
   {% set is_resolvconf_enabled = False %}
 {% endif %}


### PR DESCRIPTION
Trying again :+1: 

If `resolver:use_resolvconf` is set to True in pillar, there is a test to see if the OS is Ubuntu or Debian, and that there is a resolvconf package available. 
pkg.version only returns installed versions, and pkg.latest only returns versions available for install not already installed.  Both need to be used to satisfy the condition that this is a Debian based system, and that a resolvconf package is available to be installed.

Also switched the grain check to `os_family` to cover all Debian family systems, including Ubuntu, that should support the install of `resolvconf`.  Left it as an 'in' check, so that supported families could just be added in.
