### PR TITLE
Remove resolv.conf after purging resolvconf

### DIFF
--- a/resolver/init.sls
+++ b/resolver/init.sls
@@ -18,6 +18,18 @@ resolvconf-manage:
     - require_in:
       - file: resolv-file
 
+{%- if not is_resolvconf_enabled %}
+remove-symlink:
+  file.absent:
+    - name: /etc/resolv.conf
+    - require:
+      - resolvconf-manage
+    - require_in:
+        - resolv-file
+    - onchanges:
+      - resolvconf-manage
+{%- endif %}
+
 # Resolver Configuration
 resolv-file:
   file.managed:


### PR DESCRIPTION
If there is an existing symlink to resolv.conf then the file.managed
state will fail. Here we resolve that by destroying the resolv.conf
file if we remove resolvconf.