### PR TITLE
Make sure of resolv.conf symlink.

### DIFF
--- a/resolver/init.sls
+++ b/resolver/init.sls
@@ -1,6 +1,7 @@
 #####################################
 ##### Salt Formula For Resolver #####
 #####################################
+{% from slspath + "/map.jinja" import resolver with context %}
 
 {% if salt['pillar.get']('resolver:use_resolvconf', True) %}
   {% set is_resolvconf_enabled = grains['os_family'] in ('Debian') %}
@@ -39,6 +40,11 @@ resolv-file:
 
 {% if is_resolvconf_enabled %}
 resolv-update:
+  file.symlink:
+    - name: /etc/resolv.conf
+    - target: {{ resolver.conf_path }}
+    - force: True
+
   cmd.run:
     - name: resolvconf -u
     - onchanges:

--- a/resolver/map.jinja
+++ b/resolver/map.jinja
@@ -1,0 +1,16 @@
+{% set resolver = salt['grains.filter_by'](
+    {
+        'default': {
+            'conf_path': '/run/resolvconf/resolv.conf',
+        },
+        'Debian': {
+            'conf_path': '/etc/resolvconf/run/resolv.conf',
+        },
+        'Ubuntu': {
+            'conf_path': '../run/resolvconf/resolv.conf',
+        }
+    },
+    grain='os',
+    base='default',
+    merge=salt['pillar.get']('resolver')
+) %}


### PR DESCRIPTION
Hi,
Based on `resolvconf` man page:
> To make the resolver use this dynamically generated resolver configuration file the administrator should ensure that /etc/resolv.conf is a symbolic link to /run/resolvconf/resolv.conf. This link is normally created on installation of the resolvconf package. The link is never modified by the resolvconf program itself. If you find that /etc/resolv.conf is not being updated, please check to make sure that the link is intact.

That means if the symlink removed for any reason (e.g. manual edit), the command `resolvconf -u` will not have any effect. And since this is managed by SaltStack, then we need to make sure the symlink exists.

I did no changes in other areas, but I just introduced `map.jinja` file because the symlink path is different between distributions. (But in another PR we could replace all direct call of `pillar` with `resolver` var)

Thanks.