### PR TITLE
Prevent NetworkManager managing resolv.conf

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,7 +7,22 @@ driver:
 
 platforms:
   - name: ubuntu-14.04
-  - name: centos-7
+  - name: centos-6
+  - name: ubuntu-16.04-with-network-manager
+    driver_config:
+      image: ubuntu:16.04
+      provision_command:
+        - 'echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections'
+        - apt-get update && apt-get install -y locales ifupdown network-manager
+        - locale-gen en_US.UTF-8
+        - update-locale LANG=en_US.UTF-8
+      run_command: /lib/systemd/systemd
+  - name: centos-7-with-network-manager
+    driver_config:
+      image: centos:7
+      provision_command:
+        - yum install NetworkManager -y
+      run_command: /usr/lib/systemd/systemd
 
 provisioner:
   name: salt_solo

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ before_install:
 env:
   matrix:
     - INSTANCE: resolver-ng-ubuntu-1404
-    - INSTANCE: resolver-ng-centos-7
+    - INSTANCE: resolver-ng-centos-6
+    - INSTANCE: resolver-ng-ubuntu-1604-with-network-manager
+    - INSTANCE: resolver-ng-centos-7-with-network-manager
 
 script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ Configuration
 The ``resolvconf`` package is enabled by default for Debian based distributions
 and you can manage ``/etc/resolv.conf`` directly without remove ``resolvconf`` package.
 
+NetworkManager, if enabled, will have it's ``DNS (resolv.conf) processing mode`` disabled.
 .. code:: yaml
 
     resolver:

--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,10 @@ resolver:
   ng:
     resolvconf:
       enabled: False
+    networkmanager:
+      # Disable DNS management in NetworkManager.
+      managed: True
+      file: /etc/NetworkManager/NetworkManager.conf
   domain: example.com
   nameservers:
     - 8.8.8.8

--- a/resolver/ng/defaults.yaml
+++ b/resolver/ng/defaults.yaml
@@ -4,6 +4,13 @@ Defaults:
       enabled: False
       remove: True
       file: /run/resolvconf/resolv.conf
+    networkmanager:
+      # Will formula manage NetworkManager DNS?
+      managed: True
+      # Disable DNS management in NetworkManager.
+      dns: 'none'
+      file: /etc/NetworkManager/NetworkManager.conf
+      service: NetworkManager
   nameservers:
     - 8.8.8.8
     - 8.8.4.4

--- a/resolver/ng/init.sls
+++ b/resolver/ng/init.sls
@@ -40,3 +40,26 @@
     - onchanges:
       - file: {{ sls }}~update-resolv.conf-file
 {% endif %}
+
+# Prevent NetworkManager managing resolv.conf file.
+{% if salt['file.file_exists'](resolver.ng.networkmanager.file)
+      and resolver.ng.networkmanager.managed %}
+
+{{ sls }}~networkmanager_dns:
+  ini.options_present:
+    - name: {{ resolver.ng.networkmanager.file }}
+    - separator: '='
+    - strict: False
+    - sections:
+        main:
+          dns: {{ resolver.ng.networkmanager.dns }}
+    - onlyif: systemctl is-enabled {{ resolver.ng.networkmanager.service }}
+    - require:
+      - file: {{ sls }}~update-resolv.conf-file
+    - watch_in:
+      - service: {{ sls }}~networkmanager_dns
+  service.running:
+    - name: {{ resolver.ng.networkmanager.service }}
+    - enable: True
+
+{% endif %}


### PR DESCRIPTION
This PR addresses #26 (NetworkManager compatibility).  The [file.line](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.file.html#salt.states.file.line) state is used for simplicity.  The outcome is to prevent NetworkManager control of /etc/resolv.conf:
```
Dec 28 14:55:51 linux-ij86.suse NetworkManager[3764]: <info>  config: update /etc/NetworkManager/NetworkManager.conf (SIGHUP,value
Dec 28 14:55:51 linux-ij86.suse NetworkManager[3764]: <info>  DNS: loaded plugin unbound
Dec 28 14:55:51 linux-ij86.suse dns-resolver[31922]: ATTENTION: You have modified /etc/resolv.conf. Leaving it untouched...
Dec 28 14:55:51 linux-ij86.suse dns-resolver[31924]: You can find my version in /etc/resolv.conf.netconfig
Dec 28 14:55:51 linux-ij86.suse NetworkManager[3764]: <13>Dec 28 14:55:51 dns-resolver: ATTENTION: You have modified /etc/resolv.c
Dec 28 14:55:51 linux-ij86.suse NetworkManager[3764]: <13>Dec 28 14:55:51 dns-resolver: You can find my version in /etc/resolv.con
Dec 28 14:55:51 linux-ij86.suse NetworkManager[3764]: ATTENTION: You have modified /etc/resolv.conf.  Leaving it untouched...
Dec 28 14:55:51 linux-ij86.suse NetworkManager[3764]: You can find my version in /etc/resolv.conf.netconfig ... 
```

**UPDATE:**  Now using `file.replace` due to bug in `file.line`.

TEST CASES (file.line)

**if not found (1st run)**
```
----------
          ID: resolver.ng~disable-networkmanager-resolvconf
    Function: file.line
        Name: /etc/NetworkManager/NetworkManager.conf
      Result: True
     Comment: Changes were made
     Started: 15:28:53.441385
    Duration: 486.793 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,4 +1,5 @@
                   [main]+dns=none plugins=ifcfg-suse,keyfile 
----------
          ID: resolver.ng~disable-networkmanager-resolvconf
    Function: service.running
        Name: NetworkManager
      Result: True
     Comment: Service reloaded
     Started: 15:28:53.954906
    Duration: 30.194 ms
     Changes:   
              ----------
              NetworkManager:
                  True
```

**If already existing (reruns)**

```
          ID: resolver.ng~update-resolv.conf-file
    Function: file.managed
        Name: /etc/resolv.conf
      Result: True
     Comment: File /etc/resolv.conf is in the correct state
     Started: 15:27:08.266983
    Duration: 14.603 ms
     Changes:   
----------
          ID: resolver.ng~disable-networkmanager-resolvconf
    Function: file.line
        Name: /etc/NetworkManager/NetworkManager.conf
      Result: True
     Comment: No changes needed to be made
     Started: 15:27:08.281990
    Duration: 689.368 ms
     Changes:
```


** [file.line](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.file.html#salt.states.file.line) cannot handle Corner Cases ....**

If 'dns=dnsmasq' entry exists then https://github.com/saltstack/salt/issues/40821 occurs.
if 'dns=default' or 'dns=unbound' entry exists then NM still manages resolve.conf

```
        ID: resolver.ng~disable-networkmanager-resolvconf
    Function: file.line
        Name: /etc/NetworkManager/NetworkManager.conf
      Result: True
     Comment: Changes were made
     Started: 15:47:45.160908
    Duration: 486.041 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,4 +1,5 @@
                   [main]+dns=none dns=default plugins=ifcfg-suse,keyfile 
----------
          ID: resolver.ng~disable-networkmanager-resolvconf
    Function: service.running
        Name: NetworkManager
      Result: True
     Comment: Service reloaded
     Started: 15:47:45.668228
    Duration: 16.9 ms
     Changes:   
              ----------
              NetworkManager:
                  True
```