### PR TITLE
FreeBSD uses group 'wheel' instead of 'root'

### DIFF
--- a/resolver/init.sls
+++ b/resolver/init.sls
@@ -27,8 +27,8 @@ resolv-file:
     {% else %}
     - name: /etc/resolv.conf
     {% endif %}
-    - user: root
-    - group: root
+    - user: {{ resolver.user }}
+    - group: {{ resolver.group }}
     - mode: '0644'
     - source: salt://resolver/files/resolv.conf
     - template: jinja

--- a/resolver/map.jinja
+++ b/resolver/map.jinja
@@ -2,6 +2,8 @@
     {
         'default': {
             'conf_path': '/run/resolvconf/resolv.conf',
+            'user': 'root',
+            'group': 'root',
         },
         'Debian': {
             'conf_path': '/etc/resolvconf/run/resolv.conf',

--- a/resolver/ng/defaults.yaml
+++ b/resolver/ng/defaults.yaml
@@ -1,5 +1,7 @@
 Defaults:
   ng:
+    user: root
+    group: root
     resolvconf:
       enabled: False
       remove: True

--- a/resolver/ng/init.sls
+++ b/resolver/ng/init.sls
@@ -18,8 +18,8 @@
     - name: /etc/resolv.conf
     - follow_symlinks: False
     {% endif %}
-    - user: root
-    - group: root
+    - user: {{ resolver.ng.user }}
+    - group: {{ resolver.ng.group }}
     - mode: '0644'
     - source: salt://{{ slspath }}/templates/resolv.conf.jinja
     - template: jinja

--- a/resolver/ng/osfamilymap.yaml
+++ b/resolver/ng/osfamilymap.yaml
@@ -5,3 +5,7 @@ Debian:
       enabled: True
       remove: False
       file: /etc/resolvconf/run/resolv.conf
+FreeBSD:
+  ng:
+    user: root
+    group: wheel


### PR DESCRIPTION
Implemented basic FreeBSD support.

Tested on 
- FreeBSD 11.2
- Debian 9.5
- Ubuntu 18.04.5