### PR TITLE
fix(freebsd): add correct freebsd user and group in resolver/map.jinja

### DIFF
--- a/resolver/map.jinja
+++ b/resolver/map.jinja
@@ -13,6 +13,10 @@
         },
         'Ubuntu': {
             'conf_path': '../run/resolvconf/resolv.conf',
+        },
+        'FreeBSD': {
+            'user': 'root',
+            'group': 'wheel',
         }
     },
     grain='os',


### PR DESCRIPTION
Hello,
Just a little PR for add correct freebsd user and group in resolver/map.jinja.

